### PR TITLE
Add maven plugin to work with jitpack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'maven'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
@@ -12,4 +13,18 @@ repositories {
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile 'pl.pragmatists:JUnitParams:1.0.4'
+}
+
+install {
+  repositories.mavenInstaller {
+    pom.project {
+      licenses {
+        license {
+          name 'The Apache Software License, Version 2.0'
+          url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+          distribution 'repo'
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Hey i really love your library unfortunately i couldnt get it to work with https://jitpack.io and sbt since it couldn't find `pom.xml` so I added maven plugin to your gradle. This way it will be possible to be downloaded with jitpack